### PR TITLE
Require minimum version of Archive::Zip

### DIFF
--- a/lib/Spreadsheet/ParseXLSX.pm
+++ b/lib/Spreadsheet/ParseXLSX.pm
@@ -8,7 +8,7 @@ use 5.010;
 
 # ABSTRACT: parse XLSX files
 
-use Archive::Zip;
+use Archive::Zip 1.34;
 use Graphics::ColorUtils 'rgb2hls', 'hls2rgb';
 use Scalar::Util 'openhandle';
 use Spreadsheet::ParseExcel;


### PR DESCRIPTION
Spreadsheet::ParseXLSX has a test case that opens a scalar ref as a file.  Archive::Zip earlier than 1.34 can't support this, and fails the test.

```
error: file not seekable
 at /usr/lib/perl5/vendor_perl/5.12.3/Archive/Zip/Archive.pm line 576.
        Archive::Zip::Archive::readFromFileHandle(Archive::Zip::Archive=HASH(0x8e3ca60), GLOB(0x8d2e368)) called at /home/mconrad/.cpanm/work/1546451049.12404/Spreadsheet-ParseXLSX-0.
27/blib/lib/Spreadsheet/ParseXLSX.pm line 58
        Spreadsheet::ParseXLSX::parse(Spreadsheet::ParseXLSX=HASH(0x8d1fed0), SCALAR(0x8c85d08)) called at t/basic.t line 17
Can't open scalar ref as a zip file at /home/mconrad/.cpanm/work/1546451049.12404/Spreadsheet-ParseXLSX-0.27/blib/lib/Spreadsheet/ParseXLSX.pm line 58.
```

Requiring the minimum version of Archive::Zip prevents these failures.

Originally doy#89