### PR TITLE
Fix memory leak between Sheet and Cell, and related to XML::Twig

### DIFF
--- a/lib/Spreadsheet/ParseXLSX/Cell.pm
+++ b/lib/Spreadsheet/ParseXLSX/Cell.pm
@@ -25,16 +25,6 @@ use base 'Spreadsheet::ParseExcel::Cell';
   my $isMerged = $cell->is_merged();
   # see Spreadsheet::ParseExcel::Cell for further documentation
 
-=cut
-
-sub DESTROY {
-  my $self = shift;
-
-  #$self->SUPER::DESTROY();
-
-  undef $self->{Sheet}; # break circular dependencies
-}
-
 =method is_merged($sheet, $row, $col)
 
 Returns true if the cell is merged being part of the given sheet, located at
@@ -53,7 +43,7 @@ sub is_merged {
 
   return $self->{Merged} if defined $self->{Merged};
 
-  $sheet //= $self->{Sheet};
+  $sheet //= $Spreadsheet::ParseXLSX::Worksheet::_registry{$self->{Sheet}};
   $row //= $self->{Row};
   $col //= $self->{Col};
 

--- a/lib/Spreadsheet/ParseXLSX/Worksheet.pm
+++ b/lib/Spreadsheet/ParseXLSX/Worksheet.pm
@@ -1,0 +1,36 @@
+package Spreadsheet::ParseXLSX::Worksheet;
+
+use strict;
+use warnings;
+use Scalar::Util ();
+
+# VERSION
+
+# ABSTRACT: wrapper class around L<Spreadsheet::ParseExcel::Worksheet>
+
+=head1 DESCRIPTION
+
+This is a simple subclass of L<Spreadsheet::ParseExcel::Worksheet> which does
+not expose any new public behavior.  See the parent class for API details.
+
+=cut
+
+use Spreadsheet::ParseXLSX ();
+use base 'Spreadsheet::ParseExcel::Worksheet';
+
+# The object registry allows Cell objects to refer to Worksheets without
+# the overhead of a weakened reference, which can add up over millions
+# of cells.
+our %_registry;
+
+sub new {
+  my $self = shift->next::method(@_);
+  Scalar::Util::weaken($_registry{Scalar::Util::refaddr($self)} = $self);
+  $self;
+}
+
+sub DESTROY {
+  delete $_registry{Scalar::Util::refaddr($_[0])};
+}
+
+1;

--- a/t/garbage-collect.t
+++ b/t/garbage-collect.t
@@ -16,8 +16,38 @@ weaken($wb);
 weaken($ws1);
 weaken($cell);
 
-ok(!defined $wb, 'workbook freed');
-ok(!defined $ws1, 'worksheet freed');
+ok(!defined $wb, 'workbook freed');   # note explain $wb;
+ok(!defined $ws1, 'worksheet freed'); # note Devel::FindRef::track($ws1);
 ok(!defined $cell, 'cell freed' );
+
+# Now find out whether the XML::Twig instances get freed.
+my @xml_objects;
+my $xml_twig_new= \&XML::Twig::new;
+sub trace_xml_ctor {
+  my $self= &$xml_twig_new;
+  push @xml_objects, $self;
+  Scalar::Util::weaken($xml_objects[-1]);
+  $self;
+}
+{ no warnings;
+  *XML::Twig::new= \&trace_xml_ctor;
+}
+
+# Create multiple spreadsheet objects, and let them get freed
+for (1..3) {
+  Spreadsheet::ParseXLSX->new->parse('t/data/Test.xlsx');
+}
+
+TODO: {
+  local $TODO = 'Maybe a bug in XML::Twig?';
+  # I can't figure out why, but the most recent XML::Twig object remains
+  # un-collected until the next XML::Twig gets parsed.  This would indicate
+  # that rather than a self-reference, there is a global somewhere that is
+  # referring to it, and that global gets overwritten on next construction.
+  # I don't see any globals or 'state' variables in this module, so assume
+  # it must be XML::Twig or one of that one's deps.
+  is( scalar(grep defined, @xml_objects), 0, 'All XML::Twig cleaned up' )
+    or note explain(\@xml_objects);
+}
 
 done_testing;

--- a/t/garbage-collect.t
+++ b/t/garbage-collect.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use Scalar::Util 'weaken';
+
+use Spreadsheet::ParseXLSX;
+
+my $wb = Spreadsheet::ParseXLSX->new->parse('t/data/Test.xlsx');
+my $ws1 = $wb->worksheet(0);
+my $cell = $ws1->get_cell(0,0);
+
+ok(defined $wb && defined $ws1 && defined $cell, '3 object references');
+
+weaken($wb);
+weaken($ws1);
+weaken($cell);
+
+ok(!defined $wb, 'workbook freed');
+ok(!defined $ws1, 'worksheet freed');
+ok(!defined $cell, 'cell freed' );
+
+done_testing;


### PR DESCRIPTION
First, I added a different mechanism for a Cell to refer back to
the Sheet without needing a strong or even weak reference, by
"registering" active sheets in a global hash by their address.
The global registry gets cleaned up as the objects go out of scope.
This also helps with Data::Dumper type things where someone might
dump the Cell object and not want to see the whole worksheet of
a million cells dumped at them.

Then, while debugging the unit test, I discovered that XML::Twig
objects were holding onto the Worksheet objects.  I fixed that by
weakening the references to the sheet used in the XML::Twig
callbacks.

There is a final even more strange case where a XML::Twig object
doesn't get cleaned up until after the next XML::Twig object is
created.  This leaves one XML object dangling at all times, but is
relatively harmless since they don't accumulate.  I left a TODO in
the unit test for that problem.